### PR TITLE
TemplateMonad in Prop?

### DIFF
--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -29,7 +29,8 @@ Definition my_projT2 (t : typed_term) : my_projT1 t := @projT2 Type (fun T => T)
 
 (** *** The TemplateMonad type *)
 
-Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Type :=
+
+Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 (* Monadic operations *)
 | tmReturn : forall {A:Type@{t}}, A -> TemplateMonad A
 | tmBind : forall {A B : Type@{t}}, TemplateMonad A -> (A -> TemplateMonad B)
@@ -71,6 +72,132 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Type :=
 | tmExistingInstance : ident -> TemplateMonad unit
 | tmInferInstance : forall A : Type@{t}, TemplateMonad (option A)
 .
+
+Module InType.
+Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Type :=
+(* Monadic operations *)
+| tmReturn : forall {A:Type@{t}}, A -> TemplateMonad A
+| tmBind : forall {A B : Type@{t}}, TemplateMonad A -> (A -> TemplateMonad B)
+                           -> TemplateMonad B
+
+(* General commands *)
+| tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
+| tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
+
+(* Return the defined constant *)
+| tmDefinition : ident -> forall {A:Type@{t}}, A -> TemplateMonad A
+| tmAxiom : ident -> forall A : Type@{t}, TemplateMonad A
+| tmLemma : ident -> forall A : Type@{t}, TemplateMonad A
+
+(* Guaranteed to not cause "... already declared" error *)
+| tmFreshName : ident -> TemplateMonad ident
+
+| tmAbout : ident -> TemplateMonad (option global_reference)
+| tmCurrentModPath : unit -> TemplateMonad string
+
+(* Quote the body of a definition or inductive. Its name need not be fully qualified *)
+| tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
+| tmQuoteUniverses : unit -> TemplateMonad uGraph.t
+| tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_entry
+| tmMkDefinition : ident -> Ast.term -> TemplateMonad unit
+    (* unquote before making the definition *)
+    (* FIXME take an optional universe context as well *)
+| tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
+| tmUnquote : Ast.term  -> TemplateMonad typed_term@{u}
+| tmUnquoteTyped : forall A : Type@{t}, Ast.term -> TemplateMonad A
+
+(* Typeclass registration and querying for an instance *)
+| tmExistingInstance : ident -> TemplateMonad unit
+| tmInferInstance : forall A : Type@{t}, TemplateMonad (option A)
+.
+End InType.
+
+Module TMAbs.
+  Record TMInstance@{t u r} := {
+      TemplateMonad : Type@{t} -> Type@{r}
+; tmReturn : forall {A:Type@{t}}, A -> TemplateMonad A
+; tmBind : forall {A B : Type@{t}}, TemplateMonad A -> (A -> TemplateMonad B)
+                           -> TemplateMonad B
+
+(* General commands *)
+; tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
+; tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
+
+(* Return the defined constant *)
+; tmDefinition : ident -> forall {A:Type@{t}}, A -> TemplateMonad A
+; tmAxiom : ident -> forall A : Type@{t}, TemplateMonad A
+; tmLemma : ident -> forall A : Type@{t}, TemplateMonad A
+
+(* Guaranteed to not cause "... already declared" error *)
+; tmFreshName : ident -> TemplateMonad ident
+
+; tmAbout : ident -> TemplateMonad (option global_reference)
+; tmCurrentModPath : unit -> TemplateMonad string
+
+(* Quote the body of a definition or inductive. Its name need not be fully qualified *)
+; tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
+; tmQuoteUniverses : unit -> TemplateMonad uGraph.t
+; tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_entry
+; tmMkDefinition : ident -> Ast.term -> TemplateMonad unit
+    (* unquote before making the definition *)
+    (* FIXME take an optional universe context as well *)
+; tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
+; tmUnquote : Ast.term  -> TemplateMonad typed_term@{u}
+; tmUnquoteTyped : forall A : Type@{t}, Ast.term -> TemplateMonad A
+
+(* Typeclass registration and querying for an instance *)
+; tmExistingInstance : ident -> TemplateMonad unit
+; tmInferInstance : forall A : Type@{t}, TemplateMonad (option A)
+}.
+End TMAbs.
+  Definition PropInstance@{t u r}: TMAbs.TMInstance@{t u r} :=
+    {|
+      TMAbs.TemplateMonad := TemplateMonad@{t u}
+;TMAbs.tmReturn:=@tmReturn
+;TMAbs.tmBind:=@tmBind
+;TMAbs.tmFail:=@tmFail
+;TMAbs.tmEval:=@tmEval
+;TMAbs.tmDefinition:=@tmDefinition
+;TMAbs.tmAxiom:=@tmAxiom
+;TMAbs.tmLemma:=@tmLemma
+;TMAbs.tmFreshName:=@tmFreshName
+;TMAbs.tmAbout:=@tmAbout
+;TMAbs.tmCurrentModPath:=@tmCurrentModPath
+;TMAbs.tmQuoteInductive:=@tmQuoteInductive
+;TMAbs.tmQuoteUniverses:=@tmQuoteUniverses
+;TMAbs.tmQuoteConstant:=@tmQuoteConstant
+;TMAbs.tmMkDefinition:=@tmMkDefinition
+;TMAbs.tmMkInductive:=@tmMkInductive
+;TMAbs.tmUnquote:=@tmUnquote
+;TMAbs.tmUnquoteTyped:=@tmUnquoteTyped
+;TMAbs.tmExistingInstance:=@tmExistingInstance
+;TMAbs.tmInferInstance:=@tmInferInstance
+    |}.
+
+  Definition TypeInstance@{t u r}: TMAbs.TMInstance@{t u r} :=
+    {|
+      TMAbs.TemplateMonad := InType.TemplateMonad@{t u}
+;TMAbs.tmReturn:=@InType.tmReturn
+;TMAbs.tmBind:=@InType.tmBind
+;TMAbs.tmFail:=@InType.tmFail
+;TMAbs.tmEval:=@InType.tmEval
+;TMAbs.tmDefinition:=@InType.tmDefinition
+;TMAbs.tmAxiom:=@InType.tmAxiom
+;TMAbs.tmLemma:=@InType.tmLemma
+;TMAbs.tmFreshName:=@InType.tmFreshName
+;TMAbs.tmAbout:=@InType.tmAbout
+;TMAbs.tmCurrentModPath:=@InType.tmCurrentModPath
+;TMAbs.tmQuoteInductive:=@InType.tmQuoteInductive
+;TMAbs.tmQuoteUniverses:=@InType.tmQuoteUniverses
+;TMAbs.tmQuoteConstant:=@InType.tmQuoteConstant
+;TMAbs.tmMkDefinition:=@InType.tmMkDefinition
+;TMAbs.tmMkInductive:=@InType.tmMkInductive
+;TMAbs.tmUnquote:=@InType.tmUnquote
+;TMAbs.tmUnquoteTyped:=@InType.tmUnquoteTyped
+;TMAbs.tmExistingInstance:=@InType.tmExistingInstance
+;TMAbs.tmInferInstance:=@InType.tmInferInstance
+    |}.
+  (* Monadic operations *)
 
 Definition print_nf {A} (msg : A) : TemplateMonad unit
   := tmBind (tmEval all msg) tmPrint.


### PR DESCRIPTION
@gmalecha and I are running into issues into universe inconsistencies which go away when we put `TemplateMonad _` in `Prop`.
Can we revisit the decision to put it in `Prop`?
AFAIK, there are two disadvantages of  `(TemplateMonad _):Prop`.
(1) `(TemplateMonad _):Prop`  prevents us from writing Gallina programs that inspect template programs (of type `TemplateMonad _)`)  to, e.g., transform them to other programs.
(2) `(TemplateMonad _):Prop`  prevents us from running template programs after extraction: After extraction, anything of type `TemplateMonad _` gets erased instead of being extracted to a function that can natively run in OCaml.

I don't know any use case for (1), so I will ignore it for now. If others have non-contrived use cases in mind, please post here. 
(2) is important for efficiency and below I describe a workaround that @gmalecha and I came up with.

First, some operations in `TemplateMonad _` cannot be implemented after extraction to OCaml. In particular, operations that take arguments that are parametric over any type (their signature begins with `forall {A:Type@{t}}, A ->`) are unrealizable in OCaml. As an example, consider `tmQuote:forall {A:Type@{t}}, A  -> TemplateMonad Ast.term`
Consider the case when `A:=nat->nat`. In the OCaml interpreter that runs
template programs without extraction, the second argument of `tmQuote` will be a `Term.Constr` representing the AST of a gallina function. However, after extraction, the argument would be an OCaml function of type `Nat->Nat`, where `Nat` is the OCaml datatype extracted from the Gallina `nat`.  In OCaml, it is impossible to get the internal representation of an OCaml function.
Similarly, `tmPrint` cannot be implemented to run after extraction.

In many applications, there is a workaround for `tmQuote`. In my applications, instead of `tmQuote`,  I used `tmQuoteConstant: kername -> bool -> TemplateMonad constant_entry` , or `tmQuoteInductive` which are implementable. 

The upshot of the above discussion is that the full `TemplateMonad` type does not make sense anyway for extraction. So, can we then have inductive definitions, say `TemplateMonad` and `InType.TemplateMonad`, such that 
`(TemplateMonad _):Prop` and `(InType.TemplateMonad _):Type`?
If we want to write programs that we wish to run both ways, we can write them against an interface, say `TMInstance` which can be instantiated both by 
`TemplateMonad` and `InType.TemplateMonad`, as shown in this PR.
This PR is just to start a discussion and is not ready to be merged: it does not even build.