### PR TITLE
adapt to coq/coq#14314

### DIFF
--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -2240,7 +2240,7 @@ Proof.
   sigma. rewrite hlen.
   rewrite -subst_compose_assoc.
   rewrite shiftn_Upn. sigma.
-  rewrite subst_consn_shiftn. 2:now len.
+  (rewrite subst_consn_shiftn; try now len); [].
   now rewrite subst_consn_shiftn; sigma.
 Qed.
 

--- a/pcuic/theories/PCUICInst.v
+++ b/pcuic/theories/PCUICInst.v
@@ -2210,7 +2210,7 @@ Proof.
       eapply inst_ext_closed.
       intros x Hx.
       rewrite subst_consn_lt /=; len; try lia.
-      rewrite Upn_comp. 2:now repeat len.
+      (rewrite Upn_comp; try now repeat len); [].
       rewrite subst_consn_lt /=; len; try lia.
       now rewrite map_rev.
   - intros Σ wfΣ Γ wfΓ mfix n decl types hguard hnth htypes hmfix ihmfix wffix Δ σ hΔ hσ.

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -2190,9 +2190,9 @@ Section Rho.
           rewrite -H1. sigma.
           apply inst_ext.
           rewrite -ren_shiftn. sigma.
-          rewrite Upn_comp ?map_length ?fix_subst_length ?map_length //.
+          (rewrite Upn_comp ?map_length ?fix_subst_length ?map_length //;
+            try now autorewrite with len); [].
           apply subst_consn_proper => //.
-          2:now autorewrite with len.
           rewrite map_cofix_subst' //. 
           intros n'; simp rho. simpl; f_equal. now simp rho.
           rewrite map_cofix_subst' //.
@@ -2266,9 +2266,9 @@ Section Rho.
         sigma. autorewrite with len.
         apply inst_ext.
         rewrite -ren_shiftn. sigma.
-        rewrite Upn_comp ?map_length ?fix_subst_length ?map_length //.
+        (rewrite Upn_comp ?map_length ?fix_subst_length ?map_length //;
+          try now autorewrite with len); [].
         apply subst_consn_proper => //.
-        2:now autorewrite with len.
         rewrite map_cofix_subst' //. 
         intros n0. simpl. now rewrite up_Upn.
         rewrite !map_map_compose.
@@ -2931,7 +2931,8 @@ Section Rho.
   Proof.
     intros Hs. sigma.
     apply inst_ext.
-    rewrite shift_subst_consn_ge. 2:lia. now sigma.
+    (rewrite shift_subst_consn_ge; try by lia); [].
+    now sigma.
   Qed.
 
   Lemma pred_subst_rho_cofix (Γ Γ' rΓ : context) (mfix0 mfix1 : mfixpoint term) idx :

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -320,10 +320,11 @@ Proof.
   intros hlen.
   rewrite /to_extended_list /case_branch_context /case_branch_context_gen.
   rewrite /pre_case_branch_context_gen /inst_case_context /cstr_branch_context.
-  rewrite to_extended_list_set_binder_name.
-  rewrite to_extended_list_k_subst /expand_lets_ctx /expand_lets_k_ctx; substu.
-  rewrite PCUICLiftSubst.map_subst_instance_to_extended_list_k to_extended_list_k_subst
-    to_extended_list_k_lift_context to_extended_list_k_subst //.
+  (rewrite to_extended_list_set_binder_name;
+    try by
+     rewrite to_extended_list_k_subst /expand_lets_ctx /expand_lets_k_ctx; substu;
+     rewrite PCUICLiftSubst.map_subst_instance_to_extended_list_k to_extended_list_k_subst
+       to_extended_list_k_lift_context to_extended_list_k_subst); [].
   induction hlen; cbn. constructor.
   rewrite subst_context_snoc /= expand_lets_ctx_snoc subst_context_snoc.
   constructor. now cbn. apply IHhlen.

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -1572,7 +1572,7 @@ Qed.
 
 Lemma shiftn_Upn n σ : ↑^n ∘s ⇑^n σ =1 σ ∘s ↑^n.
 Proof.
-  unfold Upn. rewrite subst_consn_shiftn; [reflexivity|].
+  unfold Upn. rewrite subst_consn_shiftn //.
   now rewrite idsn_length.
 Qed.
 #[global]
@@ -2139,14 +2139,12 @@ Proof.
     autorewrite with sigma.
     rewrite subst_consn_compose.
     rewrite -shiftk_compose subst_compose_assoc.
-    rewrite subst_consn_shiftn.
-    2:now autorewrite with len.
+    (rewrite subst_consn_shiftn; try now autorewrite with len); [].
     autorewrite with sigma.
     rewrite -shiftk_shift.
     rewrite -shiftk_compose subst_compose_assoc.
-    rewrite subst_consn_shiftn.
-    2:now autorewrite with len.
-    now autorewrite with sigma.
+    (rewrite subst_consn_shiftn; try now autorewrite with sigma); [].
+    now autorewrite with len.
 Qed.
 
 Lemma shift_subst_consn_ge (n : nat) (l : list term) (σ : nat -> term) :

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -2429,8 +2429,7 @@ Section WfEnv.
         unfold Upn. rewrite subst_consn_compose.
         autorewrite with sigma.
         apply subst_consn_proper.
-        2:{ rewrite subst_consn_shiftn.
-            2:now autorewrite with len.
+        2:{ (rewrite subst_consn_shiftn; try now autorewrite with len); [].
             autorewrite with sigma.
             rewrite subst_consn_shiftn //.
             rewrite List.rev_length.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -1263,12 +1263,13 @@ Proof.
       epose proof (untyped_subslet_nth_error _ _ _ _ _ _ subs hnth hs).
       rewrite hb in X; rewrite X; cbn.
       rewrite subst_inst Upn_0 inst_assoc. apply inst_ext.
-      rewrite skipn_subst. 2:lia.
+      (rewrite skipn_subst; try by lia); [].
       rewrite !subst_compose_assoc.
       rewrite subst_consn_compose. sigma. 
       rewrite -subst_compose_assoc -shiftk_shift -subst_compose_assoc.
       rewrite -shiftk_shift.
-      rewrite (shift_subst_consn_ge (S n)). 2:len; lia. now len.
+      (rewrite (shift_subst_consn_ge (S n)); try by len; lia); [].
+      now len.
     * left; exists (n - #|s|), decl.
       pose proof (untyped_subslet_length subs).
       repeat split.

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -748,10 +748,9 @@ Proof.
   apply satisfies_union; simpl; split.
   - destruct φ as [φ|[φ1 φ2]].
     + cbn. apply satisfies_subst_instance_ctr; tas.
-      rewrite equal_subst_instance_cstrs_mono; aa.
-      * intros c Hc; apply Hsub in Hc. now apply Hv in Hc.
-      * intros c Hc; eapply monomorphic_global_constraint_ext; tea.
-        apply CS.union_spec; now left.
+      (rewrite equal_subst_instance_cstrs_mono; aa; try by move=> ? /Hsub/Hv); [].
+      intros c Hc; eapply monomorphic_global_constraint_ext; tea.
+      apply CS.union_spec; now left.
     + destruct HH as [_ [_ H1]].
       unfold valid_constraints in H1; rewrite Hcf in H1.
       apply satisfies_subst_instance_ctr; aa.


### PR DESCRIPTION
ssr rewrite order was wrong in case of a setoid relation.
this commit makes the code compile with both orders.