### PR TITLE
Adapt to rocq-prover/rocq#20397 (removal of sort families)

### DIFF
--- a/template-rocq/src/ast_denoter.ml
+++ b/template-rocq/src/ast_denoter.ml
@@ -25,7 +25,7 @@ struct
   type quoted_proj = projection
   type quoted_global_reference = global_reference
 
-  type quoted_sort_family = Universes0.allowed_eliminations
+  type quoted_sort_quality_or_set = Universes0.allowed_eliminations
   type quoted_constraint_type = Universes0.ConstraintType.t
   type quoted_univ_constraint = Universes0.UnivConstraint.t
   type quoted_univ_constraints = Universes0.ConstraintSet.t

--- a/template-rocq/src/ast_quoter.ml
+++ b/template-rocq/src/ast_quoter.ml
@@ -26,7 +26,7 @@ struct
   type quoted_proj = projection
   type quoted_global_reference = global_reference
 
-  type quoted_sort_family = Universes0.allowed_eliminations
+  type quoted_sort_quality_or_set = Universes0.allowed_eliminations
   type quoted_constraint_type = Universes0.ConstraintType.t
   type quoted_univ_constraint = Universes0.UnivConstraint.t
   type quoted_univ_constraints = Universes0.ConstraintSet.t
@@ -105,12 +105,13 @@ struct
   | Sorts.Type u -> Universes0.Sort.Coq_sType (quote_universe u)
   | Sorts.QSort (_, u) -> Universes0.Sort.Coq_sType (quote_universe u) (* FIXME *)
 
-  let quote_sort_family s =
+  let quote_sort_quality_or_set s =
+    let open UnivGen.QualityOrSet in
     match s with
-    | Sorts.InSProp -> Universes0.IntoSProp
-    | Sorts.InProp -> Universes0.IntoPropSProp
-    | Sorts.InSet -> Universes0.IntoSetPropSProp
-    | Sorts.InType -> Universes0.IntoAny
+    | Qual (QConstant QSProp) -> Universes0.IntoSProp
+    | Qual (QConstant QProp) -> Universes0.IntoPropSProp
+    | Set -> Universes0.IntoSetPropSProp
+    | Qual (QConstant QType) -> Universes0.IntoAny
     | _ -> Universes0.IntoAny
 
   let quote_cast_kind = function

--- a/template-rocq/src/constr_quoter.ml
+++ b/template-rocq/src/constr_quoter.ml
@@ -349,12 +349,12 @@ struct
   | Sorts.Type u -> constr_mkApp (sType, [| Lazy.force tuniverse; quote_universe u |])
   | Sorts.QSort (_, u) -> constr_mkApp (sType, [| Lazy.force tuniverse; quote_universe u |]) (* FIXME *)
 
-  let quote_sort_family = function
-    | Sorts.InProp -> Lazy.force sfProp
-    | Sorts.InSet -> Lazy.force sfSet
-    | Sorts.InType -> Lazy.force sfType
-    | Sorts.InQSort -> Lazy.force sfType (* FIXME *)
-    | Sorts.InSProp -> Lazy.force sfSProp
+  let quote_sort_quality_or_set = function
+    | UnivGen.QualityOrSet.(Qual (QConstant QProp)) -> Lazy.force sfProp
+    | UnivGen.QualityOrSet.Set -> Lazy.force sfSet
+    | UnivGen.QualityOrSet.(Qual (QConstant QType)) -> Lazy.force sfType
+    | UnivGen.QualityOrSet.(Qual (QVar _)) -> Lazy.force sfType (* FIXME *)
+    | UnivGen.QualityOrSet.(Qual (QConstant QSProp)) -> Lazy.force sfSProp
 
   let quote_context_decl na b t =
     constr_mkApp (tmkdecl, [| Lazy.force tTerm; na; quote_optionl tTerm b; t |])

--- a/template-rocq/src/constr_reification.ml
+++ b/template-rocq/src/constr_reification.ml
@@ -20,7 +20,7 @@ struct
   type quoted_pstring = Constr.t (* of type Float64.t *)
   type quoted_global_reference = Constr.t (* of type Ast.global_reference *)
 
-  type quoted_sort_family = Constr.t (* of type Ast.sort_family *)
+  type quoted_sort_quality_or_set = Constr.t (* of type Ast.sort_family *)
   type quoted_constraint_type = Constr.t (* of type Universes.constraint_type *)
   type quoted_univ_constraint = Constr.t (* of type Universes.univ_constraint *)
   type quoted_univ_constraints = Constr.t (* of type Universes.constraints *)

--- a/template-rocq/src/quoter.ml
+++ b/template-rocq/src/quoter.ml
@@ -96,7 +96,7 @@ sig
   val quote_int : int -> quoted_int
   val quote_bool : bool -> quoted_bool
   val quote_sort : Sorts.t -> quoted_sort
-  val quote_sort_family : Sorts.family -> quoted_sort_family
+  val quote_sort_quality_or_set : UnivGen.QualityOrSet.t -> quoted_sort_quality_or_set
   val quote_cast_kind : Constr.cast_kind -> quoted_cast_kind
   val quote_kn : KerName.t -> quoted_kernel_name
   val quote_inductive : quoted_kernel_name * quoted_int -> quoted_inductive
@@ -143,7 +143,7 @@ sig
     quoted_context (* ind indices context *) *
     quoted_sort (* ind sort *) *
     t (* ind type *) *
-    quoted_sort_family *
+    quoted_sort_quality_or_set *
     (quoted_ident * quoted_context (* arguments context *) *
       t list (* indices in the conclusion *) *
       t (* constr type *) *
@@ -450,12 +450,12 @@ struct
                 in ps, acc
             | _ -> [], acc
           in
-          (* TODO quote the real squash data instead of approximating with a sort family *)
+          (* TODO quote the real squash data instead of approximating with a quality or set *)
           let kelim = match oib.Declarations.mind_squashed with
-            | None -> Sorts.InType
-            | Some _ -> Sorts.family oib.mind_sort
+            | None -> UnivGen.QualityOrSet.qtype
+            | Some _ -> UnivGen.QualityOrSet.of_sort oib.mind_sort
           in
-          let sf = Q.quote_sort_family kelim in
+          let sf = Q.quote_sort_quality_or_set kelim in
             (Q.quote_ident oib.mind_typename, indices, indsort, indty, sf,
              (List.rev reified_ctors), projs, Q.quote_relevance oib.mind_relevance) :: ls, acc)
         ([],acc) (Array.to_list mib.mind_packets)

--- a/template-rocq/src/reification.ml
+++ b/template-rocq/src/reification.ml
@@ -20,7 +20,7 @@ sig
 
   type quoted_global_reference
 
-  type quoted_sort_family
+  type quoted_sort_quality_or_set
   type quoted_constraint_type
   type quoted_univ_constraint
   type quoted_univ_constraints

--- a/template-rocq/theories/AstUtils.v
+++ b/template-rocq/theories/AstUtils.v
@@ -383,7 +383,7 @@ Definition mkCase_old (Σ : global_env) (ci : case_info) (p : term) (c : term) (
       tt oib.(ind_ctors) brs ;;
   ret (tCase ci p' c brs').
 
-Definition default_sort_family (s : sort) : allowed_eliminations :=
+Definition default_sort_quality_or_set (s : sort) : allowed_eliminations :=
   match s with
   | sSProp => IntoSProp
   | sProp => IntoPropSProp
@@ -417,7 +417,7 @@ Definition make_inductive_body (id : ident) (params : context) (indices : contex
      ind_indices := indices;
      ind_sort := s;
      ind_type := it_mkProd_or_LetIn (params ,,, indices) (tSort s);
-     ind_kelim := default_sort_family s;
+     ind_kelim := default_sort_quality_or_set s;
      ind_ctors := ind_ctors;
      ind_projs := [];
      ind_relevance := relevance_of_sort s |}.


### PR DESCRIPTION
Replaced type families by `sort_quality_or_set` in `template-rocq`.