### PR TITLE
Correct a broken link to the dependency graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See [DOC.md](https://github.com/MetaRocq/metarocq/blob/-/DOC.md)
 At the center of this project is the Template-Rocq quoting library for
 Rocq. The project currently has a single repository extending
 Template-Rocq with additional features. Each extension is in a dedicated folder.
-The [dependency graph](https://raw.githubusercontent.com/MetaRocq/metarocq.github.io/main/assets/depgraph-2022-07-01.png)
+The [dependency graph](https://raw.githubusercontent.com/MetaRocq/metarocq.github.io/master/assets/depgraph-2022-07-01.png)
 might be useful to navigate the project.
 Statistics: ~300kLoC of Rocq, ~30kLoC of OCaml.
 


### PR DESCRIPTION
I'm not sure we want this link anyway, given that the dependency graph is 2+ years old and the `generate-depgraph.sh` script is broken beyond repair (unless https://github.com/rocq-prover/rocq/issues/13636 miraculously moves). Should we simply clean this up?

On the other hand, having a dependency graph is very nice (at least it greatly helped me get my feet wet in MetaRocq). I could try to see whether I can port the [small perl script](https://github.com/CoqHott/logrel-coq/blob/coq-8.20/generate_deps.pl) we have in logrel for that.

@mattam82 what do you say?