### PR TITLE
translations/minihott remove incorrect priority

### DIFF
--- a/translations/MiniHoTT.v
+++ b/translations/MiniHoTT.v
@@ -53,8 +53,8 @@ Class Transitive {A} (R : relation A) :=
   transitivity : forall x y z, R x y -> R y z -> R x z.
 
 Class PreOrder {A} (R : relation A) :=
-  { PreOrder_Reflexive : Reflexive R | 2 ;
-    PreOrder_Transitive : Transitive R | 2 }.
+  { PreOrder_Reflexive : Reflexive R ;
+    PreOrder_Transitive : Transitive R }.
 
 Global Existing Instance PreOrder_Reflexive.
 Global Existing Instance PreOrder_Transitive.

--- a/translations/MiniHoTT_paths.v
+++ b/translations/MiniHoTT_paths.v
@@ -56,8 +56,8 @@ Class Transitive {A} (R : relation A) :=
   transitivity : forall x y z, R x y -> R y z -> R x z.
 
 Class PreOrder {A} (R : relation A) :=
-  { PreOrder_Reflexive : Reflexive R | 2 ;
-    PreOrder_Transitive : Transitive R | 2 }.
+  { PreOrder_Reflexive : Reflexive R ;
+    PreOrder_Transitive : Transitive R }.
 
 Global Existing Instance PreOrder_Reflexive.
 Global Existing Instance PreOrder_Transitive.


### PR DESCRIPTION
These fields are not using `::` to declare instances (they use Existing Instance later) so the priority is ignored (error on rocq master).