### PR TITLE
Adapt to rocq-prover/rocq#21049.

### DIFF
--- a/template-rocq/src/denoter.ml
+++ b/template-rocq/src/denoter.ml
@@ -98,7 +98,9 @@ struct
       | ACoq_tConst (s,u) ->
         let s = D.unquote_kn s in
         let evm, u = D.unquote_universe_instance evm u in
-        evm, Constr.mkConstU (Constant.make1 s, u)
+        (* XXX use the Environ API when available *)
+        let cst = Global.constant_of_delta_kn s in
+        evm, Constr.mkConstU (cst, u)
       | ACoq_tConstruct (i,idx,u) ->
         let ind = D.unquote_inductive i in
         let evm, u = D.unquote_universe_instance evm u in


### PR DESCRIPTION
This is a dirty workaround, but it's backwards compatible and it's not currently easy to write properly. I left a comment for future fix.