### PR TITLE
Adapt to rocq-prover/rocq#21955 (rm coq-core libraries)

### DIFF
--- a/erasure-plugin/src/META.rocq-metarocq-erasure
+++ b/erasure-plugin/src/META.rocq-metarocq-erasure
@@ -1,7 +1,7 @@
 
 package "plugin" (
   directory = "."
-  requires = "coq-core.plugins.ltac rocq-metarocq-template-ocaml.plugin"
+  requires = "rocq-runtime.plugins.ltac rocq-metarocq-template-ocaml.plugin"
   archive(byte) = "metarocq_erasure_plugin.cma"
   archive(native) = "metarocq_erasure_plugin.cmxa"
   plugin(byte) = "metarocq_erasure_plugin.cma"

--- a/safechecker-plugin/src/META.rocq-metarocq-safechecker
+++ b/safechecker-plugin/src/META.rocq-metarocq-safechecker
@@ -1,7 +1,7 @@
 
 package "plugin" (
   directory = "."
-  requires = "coq-core.plugins.ltac rocq-metarocq-template-ocaml.plugin"
+  requires = "rocq-runtime.plugins.ltac rocq-metarocq-template-ocaml.plugin"
   archive(byte) = "metarocq_safechecker_plugin.cma"
   archive(native) = "metarocq_safechecker_plugin.cmxa"
   plugin(byte) = "metarocq_safechecker_plugin.cma"

--- a/template-rocq/META.rocq-metarocq-template-rocq
+++ b/template-rocq/META.rocq-metarocq-template-rocq
@@ -4,7 +4,7 @@ package "plugin" (
     description = "The MetaRocq Rocq Template Plugin"
     version = "8.20"
     directory = "src"
-    requires = "coq-core.plugins.ltac"
+    requires = "rocq-runtime.plugins.ltac"
     archive(byte) = "template_rocq.cma"
     archive(native) = "template_rocq.cmxa"
     plugin(byte) = "template_rocq.cma"


### PR DESCRIPTION
Not sure if safechecker actually needs ltac or if rocq-runtime.vernac would be enough but doesn't need to be figured out in this PR.