### PR TITLE
Refactor pipeline

### DIFF
--- a/erasure-plugin/src/g_metarocq_erasure.mlg
+++ b/erasure-plugin/src/g_metarocq_erasure.mlg
@@ -23,6 +23,7 @@ type erasure_command_args =
   | Unsafe
   | Time
   | Typed
+  | Inlining
   | BypassQeds
 
 let pr_char c = str (Char.escaped c)
@@ -44,12 +45,14 @@ type erasure_config =
   { unsafe : bool;
     time : bool;
     typed : bool;
+    inlining : bool;
     bypass_qeds : bool }
 
 let default_config =
   { unsafe = false;
     time = false;
     typed = false;
+    inlining = false;
     bypass_qeds = false }
 
 let make_erasure_config config =
@@ -57,6 +60,7 @@ let make_erasure_config config =
   { enable_unsafe = if config.unsafe then all_unsafe_passes else no_unsafe_passes ;
     enable_typed_erasure = config.typed;
     dearging_config = default_dearging_config;
+    inlining = config.inlining;
     inlined_constants = Kernames.KernameSet.empty;
     extracted_inductives = [] }
 
@@ -89,6 +93,7 @@ let interp_erase ~opaque_access args env evm c =
         | Unsafe -> aux {config with unsafe = true} args
         | Time -> aux {config with time = true} args
         | Typed -> aux {config with typed = true} args
+        | Inlining -> aux {config with inlining = true} args
         | BypassQeds -> aux {config with bypass_qeds = true} args
     in aux default_config args
   in
@@ -104,6 +109,7 @@ Valid options:\n\
 -typed       :  Run the typed erasure pipeline including a dearging phase. By default we run the pipeline without this phase.\n\
 -unsafe      :  Run also partially verified passes of the pipeline. This includes the cofix to lazy translation.\n\
 -time        :  Time each compilation phase\n\
+-inlining    :  Enable verified inlining phase\n\
 -bypass-qeds :  Bypass the use of Qed and quote opaque proofs. Beware, this can result in large memory\n\
                 consumption due to reification of large proof terms.\n\
                 By default, we use the (trusted) Template-Rocq quoting optimization that quotes every opaque term as an axiom.\n\
@@ -119,6 +125,7 @@ ARGUMENT EXTEND erase_args
 | [ "-unsafe" ] -> { Unsafe }
 | [ "-time" ] -> { Time }
 | [ "-typed" ] -> { Typed }
+| [ "-inlining" ] -> { Inlining }
 | [ "-bypass-qeds" ] -> { BypassQeds }
 END
 

--- a/erasure-plugin/theories/ETransform.v
+++ b/erasure-plugin/theories/ETransform.v
@@ -1215,7 +1215,7 @@ Next Obligation.
   repeat intro.
   split.
   + now apply wf_consts_to_values.
-  + constructor. 
+  + constructor.
     now apply consts_to_values_env_values.
 Qed.
 
@@ -1235,6 +1235,17 @@ Proof.
   apply consts_to_values_extends.
 Qed.
 
+
+#[global]
+Instance consts_to_values_transformation_ext' :
+  forall (efl : EEnvFlags) (wfl : WcbvFlags) hApp hBox hLazy,
+  TransformExt.t (consts_to_values_transformation efl wfl hApp hBox hLazy)
+    extends_eprogram extends_eprogram.
+Proof.
+  intros efl wfl hApp hBox hLazy p p' h1 h2.
+  unfold TransformExt.t, transform, consts_to_values_transformation, consts_to_values_program, extends_eprogram.
+  intros [ctx ->]. split => //. now apply consts_to_values_extends.
+Qed.
 
 From MetaRocq.Erasure Require Import EInlining.
 

--- a/erasure-plugin/theories/Erasure.v
+++ b/erasure-plugin/theories/Erasure.v
@@ -34,53 +34,47 @@ Local Obligation Tactic := program_simpl.
 
 Record unsafe_passes :=
   { cofix_to_lazy : bool;
-    inlining : bool;
-    unboxing : bool;
+    unboxing : bool; (* Unboxing is verified but relies on cofix_to_lazy which is not *)
     inductives_extraction : bool;
-    betared : bool }.
-
+    betared : bool;
+  }.
 Record erasure_configuration := {
   enable_unsafe : unsafe_passes;
   enable_typed_erasure : bool;
   dearging_config : dearging_config;
+  inlining : bool;
   inlined_constants : KernameSet.t;
   extracted_inductives : extract_inductives;
   }.
-  (* 
-  TODO:
-  add thunking
-  Add inlining at the end of verified *)
 
 Definition default_dearging_config :=
   {| overridden_masks := fun _ => None;
       do_trim_const_masks := true;
       do_trim_ctor_masks := false |}.
 
-
 Definition make_unsafe_passes b :=
   {| cofix_to_lazy := b;
-     inlining := b;
-    unboxing := b;
-    inductives_extraction := b;
+     unboxing := b;
+     inductives_extraction := b;
      betared := b |}.
 
 Definition no_unsafe_passes := make_unsafe_passes false.
 Definition all_unsafe_passes := make_unsafe_passes true.
 
-(* This runs the cofix -> fix/lazy translation as well as inlining and
+(* This runs the cofix -> fix/lazy translation as well as
   beta-redex simplification,  which are not verified. It does not do unboxing. *)
 
 Definition default_unsafe_passes :=
   {| cofix_to_lazy := true;
-      inlining := true;
-      unboxing := false;
-      inductives_extraction := true;
-      betared := true |}.
-  
+     unboxing := false;
+     inductives_extraction := true;
+     betared := true |}.
+
 Definition default_erasure_config :=
   {| enable_unsafe := default_unsafe_passes;
      dearging_config := default_dearging_config;
      enable_typed_erasure := true;
+     inlining := true;
      inlined_constants := KernameSet.empty;
      extracted_inductives := [] |}.
 
@@ -89,6 +83,7 @@ Definition safe_erasure_config :=
   {| enable_unsafe := no_unsafe_passes;
      enable_typed_erasure := false;
      dearging_config := default_dearging_config;
+     inlining := true;
      inlined_constants := KernameSet.empty;
      extracted_inductives := [];
   |}.
@@ -154,19 +149,26 @@ Program Definition optional_unsafe_transforms econf :=
      betared_transformation efl'' final_wcbv_flags).
 
 Next Obligation.
-  destruct (enable_unsafe econf) as [[] [] [] [] []] eqn:heq; cbn in * => //; intuition auto.
+  destruct (enable_unsafe econf) as [[] [] [] []] eqn:heq; cbn in * => //; intuition auto.
 Qed.
 
 Next Obligation.
-  destruct econf as [[[] [] [] [] []] ? ? ? ?] eqn:heq; simpl in *; cbn in * => //; intuition auto.
+  destruct econf as [[[] [] [] []] ? ? ? ?] eqn:heq; simpl in *; cbn in * => //; intuition auto.
 Qed.
 
 Next Obligation.
-  destruct econf as [[[] [] [] [] []] ? ? ? ?] eqn:heq; simpl in *; cbn in * => //; intuition auto.
+  destruct econf as [[[] [] [] []] ? ? ? ? ?] eqn:heq; simpl in *; cbn in * => //; intuition auto.
 Qed.
 
+Program Definition inlining_transformation econf :=
+  let wfl := EConstructorsAsBlocks.switch_cstr_as_blocks
+      (EInlineProjections.disable_projections_env_flag
+        (ERemoveParams.switch_no_params EWellformed.all_env_flags))
+  in
+   inline_transformation wfl final_wcbv_flags
+    econf.(inlined_constants) eq_refl eq_refl ▷
+    forget_inlining_info_transformation wfl _.
 
-(* TODO: Take erasure config as argument *)
 Program Definition verified_lambdabox_pipeline {guard : abstract_guard_impl} econf
   (efl := EWellformed.all_env_flags)
   : Transform.t _ _ _ EAst.term _ _
@@ -174,8 +176,6 @@ Program Definition verified_lambdabox_pipeline {guard : abstract_guard_impl} eco
    (eval_eprogram_env default_wcbv_flags)
    (* Target evaluation, with no more cases on prop, unguarded fixpoints, constructors as block *)
    (EProgram.eval_eprogram final_wcbv_flags) :=
-
-  
   (* Simulation of the guarded fixpoint rules with a single unguarded one:
     the only "stuck" fixpoints remaining are unapplied.
     This translation is a noop on terms and environments.  *)
@@ -195,21 +195,9 @@ Program Definition verified_lambdabox_pipeline {guard : abstract_guard_impl} eco
   (* First-order constructor representation *)
   constructors_as_blocks_transformation
     (efl := EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags))
-    (has_app := eq_refl) (has_pars := eq_refl) (has_rel := eq_refl) (has_box := eq_refl) (has_cstrblocks := eq_refl) ▷ 
+    (has_app := eq_refl) (has_pars := eq_refl) (has_rel := eq_refl) (has_box := eq_refl) (has_cstrblocks := eq_refl) ▷
   (* Inline the environment *)
-  inline_transformation 
-    (EConstructorsAsBlocks.switch_cstr_as_blocks
-      (EInlineProjections.disable_projections_env_flag
-        (ERemoveParams.switch_no_params EWellformed.all_env_flags)))
-    final_wcbv_flags
-    econf.(inlined_constants)
-    eq_refl
-    eq_refl ▷ 
-  forget_inlining_info_transformation 
-    ((EConstructorsAsBlocks.switch_cstr_as_blocks
-      (EInlineProjections.disable_projections_env_flag
-        (ERemoveParams.switch_no_params EWellformed.all_env_flags)))) _  
-.
+  ETransform.optional_self_transform econf.(inlining) (inlining_transformation econf).
 
 (* At the end of erasure we get a well-formed program (well-scoped globally and localy), without
    parameters in inductive declarations. The constructor applications are also transformed to a first-order
@@ -224,8 +212,9 @@ Next Obligation.
   now eapply ETransform.expanded_eprogram_env_expanded_eprogram_cstrs.
 Qed.
 
-  
-
+Next Obligation.
+  now destruct econf as [? ? ? [] ?].
+Qed.
 
 Program Definition verified_lambdabox_pipeline_mapping {guard : abstract_guard_impl} econf
   (efl := EWellformed.all_env_flags)
@@ -794,23 +783,8 @@ Program Definition verified_lambdabox_typed_pipeline (efl := EWellformed.all_env
    constructors_as_blocks_transformation
      (efl := EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags))
      (has_app := eq_refl) (has_pars := eq_refl) (has_rel := eq_refl) (has_box := eq_refl) (has_cstrblocks := eq_refl) ▷
-
-   (* Inline the environment *)
-  inline_transformation 
-    (EConstructorsAsBlocks.switch_cstr_as_blocks
-      (EInlineProjections.disable_projections_env_flag
-        (ERemoveParams.switch_no_params EWellformed.all_env_flags)))
-    final_wcbv_flags
-    econf.(inlined_constants)
-    eq_refl
-    eq_refl ▷ 
-  forget_inlining_info_transformation 
-    ((EConstructorsAsBlocks.switch_cstr_as_blocks
-      (EInlineProjections.disable_projections_env_flag
-        (ERemoveParams.switch_no_params EWellformed.all_env_flags)))) _  ▷
-   optional_unsafe_transforms econf
-   .
-
+  (* Inline the environment *)
+  ETransform.optional_self_transform econf.(inlining) (inlining_transformation econf).
  (* At the end of erasure we get a well-formed program (well-scoped globally and localy), without
     parameters in inductive declarations. The constructor applications are also transformed to a first-order
     "block"  application, of the right length, and the evaluation relation does not need to consider guarded
@@ -825,8 +799,7 @@ Next Obligation.
 Qed.
 
 Next Obligation.
-  unfold optional_unsafe_transforms. cbn.
-  destruct econf as [[[] ? ? ?] ? ? ? ?]=> //.
+  destruct econf as [? ? ? []]=> //.
 Qed.
 
 Local Obligation Tactic := intros; eauto.
@@ -1151,13 +1124,22 @@ Axiom assume_that_we_only_erase_on_welltyped_programs : forall {cf : checker_fla
   forall (p : Ast.Env.program), squash (TemplateProgram.wt_template_program p).
 
 (* This also optionally runs the cofix to fix translation *)
-Program Definition run_erase_program {guard : abstract_guard_impl} econf :=
-  if econf.(enable_typed_erasure) then run (typed_erasure_pipeline econf)
-  else run (erasure_pipeline_mapping econf ▷ (optional_unsafe_transforms econf)).
+Program Definition run_erase_program {guard : abstract_guard_impl} (econf : erasure_configuration)
+  (p : Transform.program inductives_mapping template_program) : pre pre_erasure_pipeline_mapping p -> Transform.program E.global_context EAst.term :=
+ if econf.(enable_typed_erasure) as _ return pre pre_erasure_pipeline_mapping p -> Transform.program E.global_context EAst.term then
+    run (typed_erasure_pipeline econf ▷ optional_unsafe_transforms econf) p
+  else
+   run (erasure_pipeline_mapping econf ▷ optional_unsafe_transforms econf) p.
 Next Obligation.
 Proof.
   unfold optional_unsafe_transforms; cbn.
-  destruct econf as [[[] ? ? ?] ? ? ? ?]=> //.
+  destruct econf as [[[] ? ? ?] ? ? [] ? ?]=> //; cbn in *; intuition eauto.
+Qed.
+
+Next Obligation.
+Proof.
+  unfold optional_unsafe_transforms; cbn.
+  destruct econf as [[[] ? ? ?] ? ? [] ? []]=> //; cbn in *; intuition eauto.
 Qed.
 
 Program Definition erase_and_print_template_program econf (m : inductives_mapping) (p : Ast.Env.program) : string :=
@@ -1175,10 +1157,10 @@ Qed.
 
 Definition typed_econf :=
   {| enable_unsafe := no_unsafe_passes;
-      dearging_config := default_dearging_config;
-      enable_typed_erasure := true;
-    inlined_constants := KernameSet.empty;
-    extracted_inductives := [] |}.
+     dearging_config := default_dearging_config;
+     enable_typed_erasure := true;
+     inlining := true; inlined_constants := KernameSet.empty;
+     extracted_inductives := [] |}.
 
 (* TODO: Parameterize by a configuration for dearging, allowing to, e.g., override masks. *)
 Program Definition typed_erase_and_print_template_program (p : Ast.Env.program)

--- a/erasure-plugin/theories/ErasureCorrectness.v
+++ b/erasure-plugin/theories/ErasureCorrectness.v
@@ -71,6 +71,32 @@ Proof.
   now rewrite H.
 Qed.
 
+(* Lemma obseq_compose_id
+  {env env' term term' value value' : Type}
+  {eval eval'}
+  (o : t env env' term term' value term' eval eval')
+  (o' : self_transform env' term' eval' eval')
+  (prec : forall p, post o p -> pre o' p) :
+  forall x p1 p2 v1 v2, obseq (compose o (optional_self_transform false o') prec) x p1 p2 v1 v2 <->
+      obseq o x p1 p2 v1 v2.
+Proof.
+  cbn. intros.
+  unfold run, time.
+  intros. firstorder. subst v2. exists x1. split.
+  exists x0. split => //.
+  assert (correctness o' (transform o x p1)
+  (prec (transform o x p1) (correctness o x p1)) =
+  (Transform.Transform.compose_obligation_1 o o' prec x p1)). apply proof_irrelevance.
+  now rewrite -H.
+
+  exists x1. split => //.
+  exists x0. split => //.
+  assert (correctness o' (transform o x p1)
+  (prec (transform o x p1) (correctness o x p1)) =
+  (Transform.Transform.compose_obligation_1 o o' prec x p1)). apply proof_irrelevance.
+  now rewrite H.
+Qed. *)
+
 Import EEnvMap.GlobalContextMap.
 
 Ltac destruct_compose :=
@@ -124,47 +150,71 @@ Proof.
   clear H.
   move: obseq.
   unfold verified_lambdabox_pipeline.
-  repeat destruct_compose.
-  cbn [transform forget_inlining_info_transformation] in *.
-  cbn [transform inline_transformation] in *.
-  cbn [transform rebuild_wf_env_transform] in *.
-  cbn [transform constructors_as_blocks_transformation] in *.
-  cbn [transform inline_projections_optimization] in *.
-  cbn [transform remove_match_on_box_trans] in *.
-  cbn [transform remove_params_optimization] in *.
-  cbn [transform guarded_to_unguarded_fix] in *.
-  intros ? ? ? ? ? ? ? ? ?.
-  unfold run, time.
-  cbn [obseq compose forget_inlining_info_transformation] in *.
-  cbn [obseq compose inline_transformation] in *.
-  cbn [obseq compose constructors_as_blocks_transformation] in *.
-  cbn [obseq run compose rebuild_wf_env_transform] in *.
-  cbn [obseq compose inline_projections_optimization] in *.
-  cbn [obseq compose remove_match_on_box_trans] in *.
-  cbn [obseq compose remove_params_optimization] in *.
-  cbn [obseq compose guarded_to_unguarded_fix] in *.
-  intros obs.
-  decompose [ex and prod] obs. clear obs. subst.
-  unfold run, time.
-  unfold EInlining.inline_program.
-  EInlining.destruct_inline_env.
-  unfold EConstructorsAsBlocks.transform_blocks_program. cbn [snd]. do 2 f_equal.
-  {
-    unfold EInlining.inlined_program_inlinings.
-    repeat destruct_compose.
-    intros.
+  set(ecf := econf) in *.
+  destruct econf as [? ? ? ? ? ?].
+  destruct inlining.
+  - unfold inlining_transformation.
+    cbn [optional_self_transform inlining ecf] in *.
+    rewrite obseq_compose_assoc.
+    rewrite transform_compose_assoc.
+    repeat destruct_compose; cbn [transform] in *.
+    cbn [transform forget_inlining_info_transformation] in *.
     cbn [transform inline_transformation] in *.
-    unfold EInlining.inline_program.
-    EInlining.destruct_inline_env.
-    cbn [transform constructors_as_blocks_transformation] in *.
     cbn [transform rebuild_wf_env_transform] in *.
+    cbn [transform constructors_as_blocks_transformation] in *.
     cbn [transform inline_projections_optimization] in *.
     cbn [transform remove_match_on_box_trans] in *.
     cbn [transform remove_params_optimization] in *.
     cbn [transform guarded_to_unguarded_fix] in *.
-    unfold EConstructorsAsBlocks.transform_blocks_program.
-    cbn [fst snd].
-    do 3 f_equal.
+    intros ? ? ? ? ? ? ? ? ?.
+    unfold run, time.
+    cbn [obseq compose forget_inlining_info_transformation] in *.
+    cbn [obseq compose inline_transformation] in *.
+    cbn [obseq compose constructors_as_blocks_transformation] in *.
+    cbn [obseq run compose rebuild_wf_env_transform] in *.
+    cbn [obseq compose inline_projections_optimization] in *.
+    cbn [obseq compose remove_match_on_box_trans] in *.
+    cbn [obseq compose remove_params_optimization] in *.
+    cbn [obseq compose guarded_to_unguarded_fix] in *.
+    intros obs.
+    decompose [ex and prod] obs. clear obs. subst.
+    unfold run, time.
+    cbn [transform inline_transformation] in *.
+    unfold EInlining.inline_program.
+    EInlining.destruct_inline_env.
+    unfold EConstructorsAsBlocks.transform_blocks_program. cbn [snd]. do 2 f_equal.
+    {
+      unfold EInlining.inlined_program_inlinings.
+      repeat destruct_compose.
+      intros.
+      cbn [transform inline_transformation] in *.
+      unfold EInlining.inline_program.
+      EInlining.destruct_inline_env.
+      cbn [transform constructors_as_blocks_transformation] in *.
+      cbn [transform rebuild_wf_env_transform] in *.
+      cbn [transform inline_projections_optimization] in *.
+      cbn [transform remove_match_on_box_trans] in *.
+      cbn [transform remove_params_optimization] in *.
+      cbn [transform guarded_to_unguarded_fix] in *.
+      unfold EConstructorsAsBlocks.transform_blocks_program.
+      cbn [fst snd].
+      do 3 f_equal.
+      eapply rebuild_wf_env_irr.
+      unfold EInlineProjections.optimize_program. cbn [fst snd].
+      f_equal.
+      eapply rebuild_wf_env_irr.
+      unfold EOptimizePropDiscr.remove_match_on_box_program. cbn [fst snd].
+      f_equal.
+      now eapply rebuild_wf_env_irr.
+    }
+    repeat destruct_compose.
+    intros.
+    cbn [transform rebuild_wf_env_transform] in *.
+    cbn [transform constructors_as_blocks_transformation] in *.
+    cbn [transform inline_projections_optimization] in *.
+    cbn [transform remove_match_on_box_trans] in *.
+    cbn [transform remove_params_optimization] in *.
+    cbn [transform guarded_to_unguarded_fix] in *.
     eapply rebuild_wf_env_irr.
     unfold EInlineProjections.optimize_program. cbn [fst snd].
     f_equal.
@@ -172,22 +222,41 @@ Proof.
     unfold EOptimizePropDiscr.remove_match_on_box_program. cbn [fst snd].
     f_equal.
     now eapply rebuild_wf_env_irr.
-  }
-  repeat destruct_compose.
-  intros.
-  cbn [transform rebuild_wf_env_transform] in *.
-  cbn [transform constructors_as_blocks_transformation] in *.
-  cbn [transform inline_projections_optimization] in *.
-  cbn [transform remove_match_on_box_trans] in *.
-  cbn [transform remove_params_optimization] in *.
-  cbn [transform guarded_to_unguarded_fix] in *.
-  eapply rebuild_wf_env_irr.
-  unfold EInlineProjections.optimize_program. cbn [fst snd].
-  f_equal.
-  eapply rebuild_wf_env_irr.
-  unfold EOptimizePropDiscr.remove_match_on_box_program. cbn [fst snd].
-  f_equal.
-  now eapply rebuild_wf_env_irr.
+  - cbn [optional_self_transform inlining ecf] in *.
+    repeat destruct_compose; cbn [transform] in *.
+    cbn [transform rebuild_wf_env_transform] in *.
+    cbn [transform constructors_as_blocks_transformation] in *.
+    cbn [transform inline_projections_optimization] in *.
+    cbn [transform remove_match_on_box_trans] in *.
+    cbn [transform remove_params_optimization] in *.
+    cbn [transform guarded_to_unguarded_fix] in *.
+    intros ? ? ? ? ? ? ? ?.
+    unfold run, time.
+    cbn [obseq compose constructors_as_blocks_transformation] in *.
+    cbn [obseq run compose rebuild_wf_env_transform] in *.
+    cbn [obseq compose inline_projections_optimization] in *.
+    cbn [obseq compose remove_match_on_box_trans] in *.
+    cbn [obseq compose remove_params_optimization] in *.
+    cbn [obseq compose guarded_to_unguarded_fix] in *.
+    intros obs.
+    decompose [ex and prod] obs. clear obs. subst.
+    unfold run, time.
+    unfold EConstructorsAsBlocks.transform_blocks_program. cbn [snd]. f_equal.
+    repeat destruct_compose.
+    intros.
+    cbn [transform rebuild_wf_env_transform] in *.
+    cbn [transform constructors_as_blocks_transformation] in *.
+    cbn [transform inline_projections_optimization] in *.
+    cbn [transform remove_match_on_box_trans] in *.
+    cbn [transform remove_params_optimization] in *.
+    cbn [transform guarded_to_unguarded_fix] in *.
+    eapply rebuild_wf_env_irr.
+    unfold EInlineProjections.optimize_program. cbn [fst snd].
+    f_equal.
+    eapply rebuild_wf_env_irr.
+    unfold EOptimizePropDiscr.remove_match_on_box_program. cbn [fst snd].
+    f_equal.
+    now eapply rebuild_wf_env_irr.
 Qed.
 
 From MetaRocq.Erasure Require Import Erasure Extract ErasureFunction.
@@ -1460,7 +1529,7 @@ Instance inline_transformation_fix_pres {efl : EWellformed.EEnvFlags} {wcbvf : W
 Proof.
   split; last reflexivity.
   intros [Σ t] pr fo.
-  unfold 
+  unfold
     fo_evalue_inline, fo_evalue, inline_program
   in *.
   destruct_inline_env; cbn [fst snd] in *.
@@ -1473,8 +1542,6 @@ Proof.
   destruct cstr_as_blocks; simple; try easy.
   now destruct args.
 Qed.
-
-
 
 #[global] Instance inline_transformation_pres_app {efl : EWellformed.EEnvFlags} {wcbvf : WcbvFlags}
   {has_app : has_tApp} {has_prop_case : has_tBox || ~~ with_prop_case} inlining :
@@ -1514,8 +1581,6 @@ Proof.
   split => //.
 Qed.
 
-
-
 #[global] Instance forget_inlining_pres_app {efl : EWellformed.EEnvFlags} wfl :
   ETransformPresAppLam.t
     (@forget_inlining_info_transformation efl wfl)
@@ -1528,52 +1593,120 @@ Proof.
   all: now unfold pre, forget_inlining_info_transformation, wf_eprogram in *; simple.
 Qed.
 
+#[global]
+Instance optional_transform_pres_fo b eval (tr : Transform.t E.global_context E.global_context EAst.term EAst.term EAst.term EAst.term eval eval ) f :
+  ETransformPresFO.t tr (fun p => firstorder_evalue_block p.1 p.2) (fun p => firstorder_evalue_block p.1 p.2) f ->
+  ETransformPresFO.t
+    (optional_self_transform b tr)
+    (fun p => firstorder_evalue_block p.1 p.2) (fun p => firstorder_evalue_block p.1 p.2)
+    (fun p pr fo => match b return pre (optional_self_transform b tr) p -> _ with true => fun pr => f p pr fo | false => fun _ => p end pr).
+Proof.
+  intros epr.
+  destruct b. cbn. apply epr.
+  split; trivial.
+Qed.
+
+#[global]
+Instance inlining_transformation_pres_fo econf :
+  ETransformPresFO.t
+    (@inlining_transformation econf)
+    (fun p => firstorder_evalue_block p.1 p.2) (fun p => firstorder_evalue_block p.1 p.2)
+    (fun p _ _ => let p' := EInlining.inline_program econf.(inlined_constants) p in (p'.1.1, p'.2)).
+Proof.
+  unfold inlining_transformation.
+  epose (he := ETransformPresFO.compose _ _ _ (inline_transformation
+(EConstructorsAsBlocks.switch_cstr_as_blocks (EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params all_env_flags)))
+final_wcbv_flags (inlined_constants econf) eq_refl eq_refl)
+ (forget_inlining_info_transformation
+(EConstructorsAsBlocks.switch_cstr_as_blocks
+(EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params all_env_flags))) final_wcbv_flags) _ _ _ _ _).
+  unfold ETransformPresFO.compose_compile_fo_value in he. exact he.
+Qed.
+
+#[global]
+Instance optional_inlining_transformation_pres_fo econf :
+  ETransformPresFO.t
+    (optional_self_transform econf.(Erasure.inlining) (@inlining_transformation econf))
+    (fun p => firstorder_evalue_block p.1 p.2) (fun p => firstorder_evalue_block p.1 p.2)
+    (fun p _ _ => if econf.(Erasure.inlining) then
+       let p' := EInlining.inline_program econf.(inlined_constants) p in (p'.1.1, p'.2)
+       else p).
+Proof.
+  epose (he := optional_transform_pres_fo econf.(Erasure.inlining) _ (inlining_transformation econf)
+     (fun p _ _ => let p' := EInlining.inline_program econf.(inlined_constants) p in (p'.1.1, p'.2))).
+  destruct econf as [? ? ? []]; cbn in *. apply he; tc. apply he; tc.
+Qed.
+
+#[global] Instance optional_self_transform_pres_app b eval (tr : Transform.t E.global_context E.global_context EAst.term EAst.term EAst.term EAst.term eval eval) :
+  ETransformPresAppLam.t tr (fun _ => True) (fun _ => True) ->
+  ETransformPresAppLam.t (optional_self_transform b tr) (fun _ => True) (fun _ => True).
+Proof.
+  destruct b; cbn => //.
+  intros []; split; cbn; auto.
+  intros Σ t0 u p _. specialize (transform_app _ _ _ p) as [p1 [p2 _]]. auto. now exists p1, p2.
+Qed.
 
 Lemma lambdabox_pres_fo econf :
   exists compile_value, ETransformPresFO.t (verified_lambdabox_pipeline econf) fo_evalue_map (fun p => firstorder_evalue_block p.1 p.2) compile_value /\
     forall p pr fo, (compile_value p pr fo).2 = compile_evalue_box (ERemoveParams.strip p.1 p.2) [].
 Proof.
   Opaque ERemoveParams.strip.
-  eexists.
-  split.
-  unfold verified_lambdabox_pipeline.
-  unshelve eapply ETransformPresFO.compose; tc. shelve.
-  2:intros p pr fo; unfold ETransformPresFO.compose_compile_fo_value; f_equal. 2:cbn.
-  unshelve eapply ETransformPresFO.compose; tc. shelve.
-  2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
-  unshelve eapply ETransformPresFO.compose; tc. shelve.
-  2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
-  unshelve eapply ETransformPresFO.compose; tc. shelve.
-  2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
-  unshelve eapply ETransformPresFO.compose; tc. shelve.
-  2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
-  unshelve eapply ETransformPresFO.compose; tc. shelve.
-  2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
-  unshelve eapply ETransformPresFO.compose. shelve. eapply remove_match_on_box_pres => //.
-  destruct p as [Γ t].
-  unfold inline_program.
-  destruct_inline_env.
-  unfold fo_evalue_map in fo.
-  unfold ETransformPresFO.compose_compile_fo_value; cbn -[ERemoveParams.strip ERemoveParams.strip_env inline_env] in *.
-  inversion fo; subst.
-  assert (forall inlining t l, List.map (inline inlining) l = l -> inline inlining (compile_evalue_box t l) = compile_evalue_box t l) as heq.
-  { clear.
-    intros env t l heq.
-    induction t in l, heq |- *; simpl; try easy.
-    now rewrite IHt1 //= IHt2. }
-  now rewrite heq.
+  destruct econf as [? ? ? []].
+  - eexists.
+    split.
+    unfold verified_lambdabox_pipeline.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:intros p pr fo; unfold ETransformPresFO.compose_compile_fo_value; cbn; f_equal.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    eapply remove_match_on_box_pres => //.
+    destruct p as [Γ t].
+    unfold inline_program.
+    destruct_inline_env.
+    unfold fo_evalue_map in fo.
+    unfold ETransformPresFO.compose_compile_fo_value; cbn -[ERemoveParams.strip ERemoveParams.strip_env inline_env] in *.
+    inversion fo; subst.
+    assert (forall inlining t l, List.map (inline inlining) l = l -> inline inlining (compile_evalue_box t l) = compile_evalue_box t l) as heq.
+    { clear.
+      intros env t l heq.
+      induction t in l, heq |- *; simpl; try easy.
+      now rewrite IHt1 //= IHt2. }
+    now rewrite heq.
+  - eexists.
+    split.
+    unfold verified_lambdabox_pipeline.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:intros p pr fo; unfold ETransformPresFO.compose_compile_fo_value; cbn; f_equal.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    2:unfold ETransformPresFO.compose_compile_fo_value; cbn.
+    unshelve eapply ETransformPresFO.compose; tc. shelve.
+    eapply remove_match_on_box_pres => //.
+    destruct p as [Γ t].
+    now unfold ETransformPresFO.compose_compile_fo_value; cbn -[ERemoveParams.strip ERemoveParams.strip_env inline_env] in *.
 Qed.
 
 #[local] Instance lambdabox_pres_app econf :
   ETransformPresAppLam.t (verified_lambdabox_pipeline econf) is_eta_fix_app_map (fun _ => True).
 Proof.
   unfold verified_lambdabox_pipeline.
-  do 7 (unshelve eapply ETransformPresAppLam.compose; [shelve| |tc]).
+  do 6 (unshelve eapply ETransformPresAppLam.compose; [shelve| |tc]).
   2:{ eapply remove_match_on_box_pres_app => //. }
   do 2 (unshelve eapply ETransformPresAppLam.compose; [shelve| |tc]).
   tc.
 Qed.
-
 
 Lemma expand_lets_function (wfl := default_wcbv_flags)
   {guard_impl : abstract_guard_impl}
@@ -2219,7 +2352,7 @@ Section pipeline_cond.
 
   Variable Normalisation : (forall Σ, wf_ext Σ -> PCUICSN.NormalizationIn Σ).
   Variable econf : erasure_configuration.
-  
+
   Lemma precond : pre (verified_erasure_pipeline econf) (Σ, t).
   Proof.
     hnf. destruct typing. repeat eapply conj; sq; cbn; eauto.
@@ -2248,6 +2381,18 @@ Section pipeline_cond.
   Let Σ_v := (transform (verified_erasure_pipeline econf) (Σ, v) precond2).1.
   Let v_t := compile_value_box (PCUICExpandLets.trans_global_env Σ) v [].
 
+  Lemma lookup_inline (efl := (EConstructorsAsBlocks.switch_cstr_as_blocks
+(EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params all_env_flags)))) p pr kn :
+    EGlobalEnv.lookup_env (transform (optional_self_transform (Erasure.inlining econf) (inlining_transformation econf)) p pr).1 kn =
+    option_map (if econf.(Erasure.inlining) then inline_global_decl (inline_env econf.(inlined_constants) p.1).2 else fun x => x) (EGlobalEnv.lookup_env p.1 kn).
+  Proof.
+    clear -efl.
+    destruct econf as [? ? ? []]; cbn.
+    - unfold inline_program; destruct_inline_env; cbn. eapply EInlining.lookup_env_inline.
+      apply pr.
+    - now rewrite option_map_id.
+  Qed.
+
   Opaque compose.
   Lemma verified_erasure_pipeline_lookup_env_in kn decl (efl := EInlineProjections.switch_no_params all_env_flags)
     {has_rel : has_tRel} {has_box : has_tBox} :
@@ -2273,16 +2418,10 @@ Section pipeline_cond.
   set (transform inline_projections_optimization _ _) as t5.
   set (transform (rebuild_wf_env_transform true false) _ _) as t6.
   set (transform constructors_as_blocks_transformation _ _) as t7.
-  set (transform (inline_transformation _ _ _ _ _) _ _) as t8.
-  unfold transform at 1. cbn -[transform].
-  subst t8.
-  unfold transform at 1. cbn -[transform].
-  unfold inline_program; destruct_inline_env.
-  cbn -[transform].
-  setoid_rewrite EInlining.lookup_env_inline; last first.
-  { apply H8. }
-  set (inline_global_decl _).
+  rewrite lookup_inline.
+  (* set (if _ then inline_global_decl _ else _) as t8. *)
   subst t7.
+  set (eenv := inline_env _ _). clearbody eenv.
   unfold transform at 1. cbn -[transform].
   rewrite EConstructorsAsBlocks.lookup_env_transform_blocks.
   set (EConstructorsAsBlocks.transform_blocks_decl _).
@@ -2318,12 +2457,13 @@ Section pipeline_cond.
   unshelve epose proof
     (Hlookup := lookup_env_in_erase_global_deps optimized_abstract_env_impl w t0
     _ kn _ Hyp0 decl' _ Heq).
-  { epose proof (wf_fresh_globals _ HΣ). clear - H10.
-    revert H10. cbn. set (Σ.1). induction 1; econstructor; eauto.
+  { epose proof (wf_fresh_globals _ HΣ). clear - H9.
+    revert H9. cbn. set (Σ.1). induction 1; econstructor; eauto.
     cbn. clear -H. induction H; econstructor; eauto. }
   destruct Hlookup as [decl'' [? ?]]. exists decl''; split ; eauto.
-  cbn in H12. inversion H12.
-  now destruct decl' , decl''.
+  cbn in H11. inversion H11.
+  set (b := Erasure.inlining econf) in H13 |- *. clearbody b.
+  now destruct b, decl' , decl''.
   Qed.
 
 End pipeline_cond.
@@ -2351,6 +2491,15 @@ Section pipeline_theorem.
   Variable fo : @PCUICFirstorder.firstorder_ind Σ (PCUICFirstorder.firstorder_env Σ) i.
 
   Variable Heval : ∥PCUICWcbvEval.eval Σ t v∥.
+
+  Lemma fo_v : PCUICFirstorder.firstorder_value Σ [] v.
+  Proof.
+    destruct typing, Heval. sq.
+    eapply PCUICFirstorder.firstorder_value_spec; eauto.
+    - eapply PCUICClassification.subject_reduction_eval; eauto.
+    - eapply PCUICWcbvEval.eval_to_value; eauto.
+  Qed.
+
   Variable econf : erasure_configuration.
 
   Let Σ_t := (transform (verified_erasure_pipeline econf) (Σ, t) (precond _ _ _ _ expΣ expt typing _ econf)).1.
@@ -2386,13 +2535,6 @@ Section pipeline_theorem.
       eapply PCUICExpandLetsCorrectness.trans_firstorder_env. }
   Qed.
 
-  Lemma fo_v : PCUICFirstorder.firstorder_value Σ [] v.
-  Proof.
-  destruct typing, Heval. sq.
-  eapply PCUICFirstorder.firstorder_value_spec; eauto.
-  - eapply PCUICClassification.subject_reduction_eval; eauto.
-  - eapply PCUICWcbvEval.eval_to_value; eauto.
-  Qed.
 
   Lemma v_t_spec : v_t = (transform (verified_erasure_pipeline econf) (Σ, v) (precond2 _ _ _ _ expΣ expt typing _ econf _ Heval)).2.
   Proof.

--- a/erasure/theories/EConstantsToValues.v
+++ b/erasure/theories/EConstantsToValues.v
@@ -12,7 +12,7 @@ Import Kernames.
 Import MonadNotation.
 
 (** We transform a program by transforming each constant into a value by thunking them, and forcing their evaluation when needed *)
-(* 
+(*
   TODO:
   Thunk only when the constant is not already a value
 *)
@@ -20,17 +20,17 @@ Fixpoint consts_to_values (t : term) : term :=
   match t with
   | tVar na => tVar na
   | tLambda nm bod => tLambda nm (consts_to_values bod)
-  | tLetIn nm dfn bod => 
+  | tLetIn nm dfn bod =>
       tLetIn nm (consts_to_values dfn) (consts_to_values bod)
-  | tApp fn arg => 
+  | tApp fn arg =>
       tApp (consts_to_values fn) (consts_to_values arg)
-  | tConst nm => tForce (tConst nm) 
+  | tConst nm => tForce (tConst nm)
   | tConstruct i m args => tConstruct i m (map consts_to_values args)
   | tCase i mch brs =>
       tCase i (consts_to_values mch) (map (on_snd consts_to_values) brs)
-  | tFix mfix idx => 
+  | tFix mfix idx =>
       tFix (map (map_def consts_to_values) mfix) idx
-  | tCoFix mfix idx => 
+  | tCoFix mfix idx =>
       tCoFix (map (map_def consts_to_values) mfix) idx
   | tProj p bod => tProj p (consts_to_values bod)
   | tPrim p => tPrim (map_prim consts_to_values p)
@@ -42,20 +42,20 @@ Fixpoint consts_to_values (t : term) : term :=
   end
 .
 
-Definition consts_to_values_constant_decl (cb : constant_body) : constant_body := 
+Definition consts_to_values_constant_decl (cb : constant_body) : constant_body :=
   {| cst_body := option_map (tLazy ∘ consts_to_values) cb.(cst_body)|}.
 
 
 Definition consts_to_values_global_decl (d : global_decl) : global_decl :=
   match d with
-  | ConstantDecl cb => 
+  | ConstantDecl cb =>
       ConstantDecl (consts_to_values_constant_decl cb)
   | InductiveDecl idecl => d
   end.
 Definition consts_to_values_decl (d : kername * global_decl) : kername * global_decl := on_snd consts_to_values_global_decl d.
 
 
-Definition consts_to_values_env Σ : global_context := 
+Definition consts_to_values_env Σ : global_context :=
   List.map consts_to_values_decl Σ.
 
 
@@ -71,12 +71,12 @@ Create HintDb consts_to_values_rw_hints.
 Ltac simple := repeat (
     eassumption ||
     match goal with
-    | |- All _ _ => apply Forall_All 
+    | |- All _ _ => apply Forall_All
     | H : All _ _ |- _ => apply All_Forall in H
     | h : ?e = Some _ |- _ =>
           rewrite ->h in *
     end ||
-    autorewrite with consts_to_values_rw_hints in * || 
+    autorewrite with consts_to_values_rw_hints in * ||
     simpl in *
   ).
 
@@ -134,7 +134,7 @@ Hint Rewrite lookup_env_consts_to_values : consts_to_values_rw_hints.
 
 Lemma lookup_inductive_consts_to_values ctx i :
   lookup_inductive (consts_to_values_env ctx) i = lookup_inductive ctx i.
-Proof. 
+Proof.
   unfold lookup_inductive, lookup_minductive; simple.
   destruct (lookup_env ctx (inductive_mind i)) as [[? | ?]|]; reflexivity.
 Qed.
@@ -178,7 +178,7 @@ Hint Rewrite lookup_projection_consts_to_values : consts_to_values_rw_hints.
 
 
 Lemma lookup_constant_consts_to_values ctx s :
-  lookup_constant (consts_to_values_env ctx) s = 
+  lookup_constant (consts_to_values_env ctx) s =
   option_map consts_to_values_constant_decl (lookup_constant ctx s).
 Proof.
   unfold lookup_constant.
@@ -191,7 +191,7 @@ Hint Rewrite lookup_constant_consts_to_values : consts_to_values_rw_hints.
 Lemma fresh_consts_to_values name ctx :
   fresh_global name (consts_to_values_env ctx) <-> fresh_global name ctx.
 Proof.
-  split; 
+  split;
     [intros H%Forall_map_inv | intros H; apply Forall_map];
     simple.
 Qed.
@@ -226,7 +226,7 @@ Proof.
     rewrite !map_map_compose.
     apply All_map_eq.
     now simple.
-  - f_equal.  
+  - f_equal.
     rewrite !map_map_compose.
     apply All_map_eq.
     now simple.
@@ -264,11 +264,11 @@ Lemma consts_to_values_substl l e :
   ECSubst.substl (map consts_to_values l) (consts_to_values e).
 Proof.
   unfold ECSubst.substl.
-  induction l as [| ? ? IH] 
+  induction l as [| ? ? IH]
     using list_ind_rev; simpl; first reflexivity.
   rewrite map_app !fold_left_app.
   now simple.
-Qed. 
+Qed.
 Hint Rewrite consts_to_values_substl : consts_to_values_rw_hints.
 
 
@@ -326,8 +326,8 @@ Lemma consts_to_values_constr_isprop_pars_decl ctx ind n :
   constructor_isprop_pars_decl ctx ind n.
 Proof.
   unfold constructor_isprop_pars_decl.
-  now simple. 
-Qed.  
+  now simple.
+Qed.
 Hint Rewrite consts_to_values_constr_isprop_pars_decl : consts_to_values_rw_hints.
 
 
@@ -341,7 +341,7 @@ Proof.
 Qed.
 
 Lemma consts_to_values_cst_body  decl :
-  cst_body (consts_to_values_constant_decl decl) = option_map (tLazy ∘ consts_to_values) (cst_body decl). 
+  cst_body (consts_to_values_constant_decl decl) = option_map (tLazy ∘ consts_to_values) (cst_body decl).
 Proof.
   reflexivity.
 Qed.
@@ -352,10 +352,10 @@ Lemma consts_to_values_head e :
   EAstUtils.head (consts_to_values e) = consts_to_values (EAstUtils.head e).
 Proof.
   now induction e; simpl; rewrite ?EAstUtils.head_tApp.
-Qed.  
+Qed.
 Hint Rewrite consts_to_values_head : consts_to_values_rw_hints.
 
-Lemma consts_to_values_isLambda e : 
+Lemma consts_to_values_isLambda e :
   isLambda (consts_to_values e) = isLambda e.
 Proof.
   now destruct e.
@@ -369,7 +369,7 @@ Proof.
 Qed.
 Hint Rewrite consts_to_values_isFixApp : consts_to_values_rw_hints.
 
-Lemma consts_to_values_isFix e : 
+Lemma consts_to_values_isFix e :
   EAstUtils.isFix (consts_to_values e) = EAstUtils.isFix e.
 Proof.
   now destruct e.
@@ -405,10 +405,10 @@ Qed.
 Hint Rewrite consts_to_values_isLazyApp : consts_to_values_rw_hints.
 
 Lemma consts_to_values_iota pars args br :
-  consts_to_values (iota_red pars args br) = 
-  iota_red 
-    pars 
-    (map consts_to_values args) 
+  consts_to_values (iota_red pars args br) =
+  iota_red
+    pars
+    (map consts_to_values args)
     (on_snd consts_to_values br).
 Proof.
   unfold iota_red. simple.
@@ -417,11 +417,11 @@ Qed.
 Hint Rewrite consts_to_values_iota : consts_to_values_rw_hints.
 
 
-Lemma wf_consts_to_values_same_ctx 
+Lemma wf_consts_to_values_same_ctx
   (efl : EEnvFlags)
   (t : term) (k : nat) (ctx : global_context) :
   has_tLazy_Force ->
-  wellformed ctx k t -> 
+  wellformed ctx k t ->
   wellformed ctx k (consts_to_values t).
 Proof.
   induction t using term_forall_list_ind in k |- *;
@@ -433,15 +433,15 @@ Proof.
 Qed.
 
 
-Lemma wf_consts_to_values_env_map_ctx 
-  (efl : EEnvFlags) 
+Lemma wf_consts_to_values_env_map_ctx
+  (efl : EEnvFlags)
   (t : term) (k : nat) (ctx : global_context) :
   has_tLazy_Force ->
-  wellformed ctx k t -> 
+  wellformed ctx k t ->
   wellformed (consts_to_values_env ctx) k t.
 Proof.
   induction t using term_forall_list_ind in k |- *; simple;
-  unfold wf_fix, test_def, map_prim, test_prim, test_array_model 
+  unfold wf_fix, test_def, map_prim, test_prim, test_array_model
   in *; repeat split; intros; simple; try easy.
   - now destruct (lookup_constant ctx s) as [[[|]]|].
   - now destruct cstr_as_blocks; simple.
@@ -457,10 +457,10 @@ Lemma wf_glob_consts_to_values
   wf_glob (consts_to_values_env ctx).
 Proof.
   induction ctx as [|[? [[[|]]|?]] ? ?];
-  inversion 2; subst; constructor; 
-    now rewrite /= 
-      ?wf_consts_to_values_env_map_ctx 
-      ?wf_consts_to_values_same_ctx 
+  inversion 2; subst; constructor;
+    now rewrite /=
+      ?wf_consts_to_values_env_map_ctx
+      ?wf_consts_to_values_same_ctx
       ?fresh_consts_to_values.
 Qed.
 
@@ -481,8 +481,8 @@ Qed.
 
 
 #[local] Ltac destruct_IHs :=
-    repeat match goal with 
-    | IH : _ -> 
+    repeat match goal with
+    | IH : _ ->
       eval (consts_to_values_env _) _ _
         |- _ =>
         unshelve epose proof IH _; first try easy;
@@ -491,7 +491,7 @@ Qed.
 
 
 #[local]
-Ltac solve_wf := 
+Ltac solve_wf :=
   match goal with
   | |- context[wellformed _ _ _] =>
     solve[
@@ -501,7 +501,7 @@ Ltac solve_wf :=
         | hdec : declared_constant _ ?c _ |- _ =>
             unfold lookup_constant, declared_constant in *;
             apply lookup_env_wellformed in hdec as ?
-        | heq: ?a = _, 
+        | heq: ?a = _,
               h: context[match ?a with _ => _ end] |- _ =>
                 rewrite heq in h
         | h: In _ (repeat _ _) |- _ =>
@@ -512,29 +512,29 @@ Ltac solve_wf :=
             rewrite wellformed_mkApps /=
         | h : _ /\ _ |- _ => destruct h
         | h : cunfold_fix _ _ = Some (_, ?e) |-
-            is_true (wellformed _ _ ?e) => 
+            is_true (wellformed _ _ ?e) =>
             eapply wellformed_cunfold_fix; simpl
         | h : cunfold_cofix _ _ = Some (_, ?e) |-
-            is_true (wellformed _ _ ?e) => 
+            is_true (wellformed _ _ ?e) =>
             eapply wellformed_cunfold_cofix; simpl
         | h : nth_error _ _ = Some ?a |-
               is_true (wellformed _ _ ?a) => eapply nth_error_forallb
-        | |- is_true (wellformed _ _ (iota_red _ _ _)) => 
+        | |- is_true (wellformed _ _ (iota_red _ _ _)) =>
             eapply wellformed_iota_red_brs
-        | |- is_true (wellformed _ _ (ECSubst.csubst _ _ _)) => 
+        | |- is_true (wellformed _ _ (ECSubst.csubst _ _ _)) =>
             eapply wellformed_csubst
-        | |- is_true (wellformed _ _ (ECSubst.substl _ _)) => 
+        | |- is_true (wellformed _ _ (ECSubst.substl _ _)) =>
             eapply wellformed_substl
         | |- _ /\ _ => split
-        | h : context[if ?c then _ else _] |- _ => 
+        | h : context[if ?c then _ else _] |- _ =>
             destruct c eqn:?
-        | h : is_true (is_nil ?l) |- _ => 
+        | h : is_true (is_nil ?l) |- _ =>
             destruct l; last (simpl in h; easy); clear h
         end ||
         match goal with
-        | h : eval _ _ _ |- _ => 
+        | h : eval _ _ _ |- _ =>
             apply eval_wellformed in h; [|easy..]; simpl in h
-        end 
+        end
       )
     ]
   end.
@@ -606,6 +606,6 @@ Qed.
 Theorem consts_to_values_env_values {wfl : WcbvFlags} (Σ : global_context) :
   values_glob (consts_to_values_env Σ).
 Proof.
-  induction Σ as [|[kn [[[v|]]|?]] Σ IH]; simpl; 
+  induction Σ as [|[kn [[[v|]]|?]] Σ IH]; simpl;
     repeat constructor; assumption.
 Qed.


### PR DESCRIPTION
Add a (safe) inlining option and update the correctness proof: whether inlining is on or not we have correctness and preserve observational equality of values, applications and lambdas. Also includes a minor refactoring of the pipelines to have the unsafe passes only exposed through `run_erasure_pipeline`, not in the `verified_*` pipelines.