### PR TITLE
Adapt to rocq-prover/rocq#22166 (opaque_proofterm carries a usage bit)

### DIFF
--- a/template-rocq/src/quoter.ml
+++ b/template-rocq/src/quoter.ml
@@ -553,7 +553,7 @@ struct
               | Def cs -> Some cs
               | OpaqueDef lc ->
                 if bypass then
-                  let c, univs = Global.force_proof opaque_access lc in
+                  let c, univs, _ = Global.force_proof opaque_access lc in
                   match univs with
                   | Opaqueproof.PrivateMonomorphic () -> Some c
                   | Opaqueproof.PrivatePolymorphic csts ->
@@ -677,7 +677,7 @@ struct
       | Def cs -> Some (quote_term env evm cs)
       | OpaqueDef cs ->
         if bypass
-        then Some (quote_term env evm (fst (Global.force_proof opaque_access cs)))
+        then Some (quote_term env evm (let (c, _, _) = Global.force_proof opaque_access cs in c))
         else None
       | Primitive _ -> failwith "Primitive types not supported by TemplateRocq"
       | Symbol _ -> failwith "Symbols are not supported by TemplateRocq"

--- a/template-rocq/src/run_extractable.ml
+++ b/template-rocq/src/run_extractable.ml
@@ -121,7 +121,7 @@ let get_constant_body ~opaque_access b =
   | Def b -> Some b
   | Undef inline -> None
   | OpaqueDef pr -> 
-    let proof, _ = Global.force_proof opaque_access pr in
+    let proof, _, _ = Global.force_proof opaque_access pr in
     (* FIXME delayed univs skipped *)
     Some proof
   | Primitive _ -> failwith "Primitives not supported by TemplateRocq"


### PR DESCRIPTION
*[Written by Claude (Fable 5) via Claude Code, on behalf of @JasonGross.]*

Adapt to rocq-prover/rocq#22166: `Global.force_proof` now returns a triple, adding a boolean recording whether checking the opaque proof used impredicativity of `Set` in a load-bearing way. `Print Assumptions` can then avoid re-typechecking constants that do not rely on `-impredicative-set`.

Merge in sync with rocq-prover/rocq#22166; this branch is its CI overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
