### PR TITLE
Refine constants to values

### DIFF
--- a/erasure-plugin/theories/ETransform.v
+++ b/erasure-plugin/theories/ETransform.v
@@ -1340,30 +1340,87 @@ Instance forget_inlining_info_transformation_ext' :
     extends_inlined_eprogram extends_eprogram.
 Proof.
   intros ? ? [[] ?] [[] ?]; cbn.
-  now rewrite /extends_inlined_eprogram /extends_eprogram /=.
+   now rewrite /extends_inlined_eprogram /extends_eprogram /=.
 Qed.
+
+Definition conditionally (b : bool) (P : Prop) := 
+  if b then P else True.
 
 (* Implementing box *)
 
 From MetaRocq.Erasure Require Import EImplementBox.
 
+(* It preserves values in the environment *)
+Lemma implement_box_value_pres (efl : EEnvFlags) Σ t :
+  wf_glob Σ -> @value block_wcbv_flags Σ t -> 
+  @value block_wcbv_flags (implement_box_env Σ) (implement_box t).
+Proof.
+  intros wf. revert t.
+  eapply value_values_ind.
+  - move=> -[] //= ato; simp implement_box; try solve [repeat constructor].
+    intros n [] => //.
+  - intros p hp hp'. simp implement_box.
+    apply value_atom. constructor 2. depelim hp'; constructor; auto.
+    cbn. now apply All_map.
+  - intros ind c mdecl idecl cdecl args wcb hl hnargs H IH.
+    simp implement_box. econstructor 2; eauto.
+    * now rewrite lookup_constructor_implement_box; tea.
+    * now rewrite length_map.
+    * now apply All_map.
+  - intros f args hd hargs H IH.
+    rewrite implement_box_mkApps; simp implement_box.
+    depelim hd.
+    * now cbn in e.
+    * constructor 3. rewrite length_map; simp implement_box.
+      constructor. now eapply map_nil.
+      now eapply All_map.
+    * now cbn in y.
+Qed.
+
+Lemma implement_box_values_glob_pres (efl : EEnvFlags) Σ :
+  wf_glob Σ -> ∥ @values_glob block_wcbv_flags Σ ∥ -> 
+  ∥ @values_glob block_wcbv_flags (implement_box_env Σ) ∥.
+Proof.
+  intros wf v. induction wf. sq. constructor.
+  depelim v. depelim X. specialize (IHwf (sq X)). sq. cbn. constructor => //.
+  destruct d as [[[dbody|]]|]; cbn in * |-; try solve [constructor; auto].
+  cbn -[implement_box]. 
+  eapply implement_box_value_pres; tea.
+Qed.
+
+Lemma implement_box_lambda_glob_pres (efl : EEnvFlags) Σ :
+  wf_glob Σ -> ∥ lambda_glob Σ ∥ -> 
+  ∥ lambda_glob (implement_box_env Σ) ∥.
+Proof.
+  intros wf v. induction wf. sq. constructor.
+  depelim v. depelim X. specialize (IHwf (sq X)). sq. cbn. constructor => //.
+  destruct d as [[[dbody|]]|]; cbn in * |-; try solve [constructor; auto].
+  cbn -[implement_box]. destruct d1 as [na [b ->]]. simp implement_box.
+  now eexists.
+Qed.
+
 Program Definition implement_box_transformation (efl : EEnvFlags)
   (has_app : has_tApp) (has_lam : has_tLambda) (has_letin : has_tLetIn) (nocofix : has_tCoFix = false)
-  (nopars : has_cstr_params = false):
+  (nopars : has_cstr_params = false) pres_values :
   Transform.t _ _ EAst.term EAst.term _ _ (eval_eprogram block_wcbv_flags) (eval_eprogram block_wcbv_flags) :=
   {| name := "implementing box";
     transform p _ := EImplementBox.implement_box_program p ;
-    pre p := wf_eprogram efl p ;
-    post p := wf_eprogram (switch_off_box efl) p ;
+    pre p := wf_eprogram efl p /\ conditionally pres_values (∥ lambda_glob p.1 ∥) ;
+    post p := wf_eprogram (switch_off_box efl) p /\ conditionally pres_values (∥ lambda_glob p.1 ∥);
     obseq p hp p' v v' := v' = implement_box v |}.
 Next Obligation.
-  intros. cbn in *. split.
-  - eapply implement_box_env_wf_glob; eauto. apply p.
-  - eapply transform_wellformed'. all:eauto. all: apply p.
+  intros. destruct p as [p pres]; cbn in *. split.
+  * split.
+    - eapply implement_box_env_wf_glob; eauto. apply p.
+    - eapply transform_wellformed'. all:eauto. all: apply p.
+  * destruct pres_values => //=. cbn in pres.
+    destruct p as [wf _].
+    now eapply implement_box_lambda_glob_pres.
+    (* now eapply implement_box_values_glob_pres. *)
 Qed.
 Next Obligation.
-  intros efl hasapp haslam haslet nocof nopars.
-  intros pr v wf pre.
+  intros efl hasapp haslam haslet nocof nopars pres_values.
+  intros pr v [wf pres] pre.
   destruct pr. destruct wf, pre; cbn in * |-.
   eexists. split; [ | eauto].
   econstructor.
@@ -1371,6 +1428,22 @@ Next Obligation.
 Qed.
 
 From MetaRocq.Erasure Require Import EImplementLazyForce.
+
+Lemma lazy_to_lambda_pred Σ t :
+  lazy_value_pred Σ t -> lambda_value_pred (implement_lazy_force_env Σ) (implement_lazy_force t).
+Proof.
+  intros [body eq]. subst t; simp implement_lazy_force.
+  now eexists.
+Qed.
+
+Lemma lazy_to_lambda_glob Σ : lazy_glob Σ -> lambda_glob (implement_lazy_force_env Σ).
+Proof.
+  induction 1; cbn.
+  - constructor.
+  - constructor; tea.
+    destruct d as [[[dbody|]]|]; cbn -[implement_lazy_force] in * => //.
+    now eapply lazy_to_lambda_pred.
+Qed.
 
 Lemma value_pres (efl : EEnvFlags) Σ t :
   wf_glob Σ -> @value block_wcbv_flags Σ t -> 
@@ -1414,16 +1487,17 @@ Program Definition implement_lazy_force_transformation (efl : EEnvFlags) (has_ap
   Transform.t _ _ EAst.term EAst.term _ _ (eval_eprogram block_wcbv_flags) (eval_eprogram block_wcbv_flags) :=
   {| name := "implementing lazy and force using lambdas ";
     transform p _ := implement_lazy_force_program p ;
-    pre p := wf_eprogram efl p /\ (if pres_values then ∥ @values_glob block_wcbv_flags p.1 ∥ else True) ;
+    pre p := wf_eprogram efl p /\ 
+      (if pres_values then ∥ lazy_glob p.1 ∥ else True) ;
     post p := wf_eprogram (switch_off_thunk efl) p /\ 
-      (if pres_values then ∥ @values_glob block_wcbv_flags p.1 ∥ else True) ;
+      (if pres_values then ∥ lambda_glob p.1 ∥ else True) ;
     obseq p hp p' v v' := v' = implement_lazy_force v |}.
 Next Obligation.
   intros efl hasapp haslam hasbox nocof nopars pvals p [wfp hpres].
   split.
   - split. eapply implement_lazy_force_env_wf_glob; eauto. apply wfp.
     apply transform_wellformed'; eauto. all:apply wfp.
-  - destruct pvals => //. eapply values_glob_pres; eauto. apply wfp.
+  - destruct pvals => //. sq. now apply lazy_to_lambda_glob.
 Qed.
 Next Obligation.
   intros efl hasapp haslam hasbox nocof nopars pvals p t [wf hpres] ev.

--- a/erasure-plugin/theories/ETransform.v
+++ b/erasure-plugin/theories/ETransform.v
@@ -1215,7 +1215,7 @@ Program Definition consts_to_values_transformation (efl : EEnvFlags) (wfl : Wcbv
   {| name := "Constants to values";
     transform p _ := consts_to_values_program p ;
     pre p := wf_eprogram efl p ;
-    post (p : eprogram) := wf_eprogram efl p /\ ∥values_glob p.1∥ ;
+    post (p : eprogram) := wf_eprogram efl p /\ ∥ lazy_glob p.1∥ ;
     obseq p hp (p' : eprogram) v v' := v' = consts_to_values v |}.
 
 Next Obligation.
@@ -1223,7 +1223,7 @@ Next Obligation.
   split.
   + now apply wf_consts_to_values.
   + constructor.
-    now apply consts_to_values_env_values.
+    now apply consts_to_values_env_lazy.
 Qed.
 
 Next Obligation.

--- a/erasure-plugin/theories/ETransform.v
+++ b/erasure-plugin/theories/ETransform.v
@@ -1207,7 +1207,6 @@ Proof.
 Qed.
 
 
-
 From MetaRocq.Erasure Require Import EConstantsToValues.
 
 Program Definition consts_to_values_transformation (efl : EEnvFlags) (wfl : WcbvFlags) (hApp : has_tApp) (hBox : has_tBox || ~~with_prop_case) (hLazy : has_tLazy_Force) :
@@ -1373,21 +1372,61 @@ Qed.
 
 From MetaRocq.Erasure Require Import EImplementLazyForce.
 
+Lemma value_pres (efl : EEnvFlags) Σ t :
+  wf_glob Σ -> @value block_wcbv_flags Σ t -> 
+  @value block_wcbv_flags (implement_lazy_force_env Σ) (implement_lazy_force t).
+Proof.
+  intros wf. revert t.
+  eapply value_values_ind.
+  - move=> -[] //= ato; simp implement_lazy_force; try solve [repeat constructor].
+    intros n [] => //.
+  - intros p hp hp'. simp implement_lazy_force.
+    apply value_atom. constructor 2. depelim hp'; constructor; auto.
+    cbn. now apply All_map.
+  - intros ind c mdecl idecl cdecl args wcb hl hnargs H IH.
+    simp implement_lazy_force. econstructor 2; eauto.
+    * now rewrite lookup_constructor_implement_lazy_force; tea.
+    * now rewrite length_map.
+    * now apply All_map.
+  - intros f args hd hargs H IH.
+    rewrite implement_lazy_force_mkApps; simp implement_lazy_force.
+    depelim hd.
+    * now cbn in e.
+    * constructor 3. rewrite length_map; simp implement_lazy_force.
+      constructor. now eapply map_nil.
+      now eapply All_map.
+    * now cbn in y.
+Qed.
+
+Lemma values_glob_pres (efl : EEnvFlags) Σ :
+  wf_glob Σ -> ∥ @values_glob block_wcbv_flags Σ ∥ -> 
+  ∥ @values_glob block_wcbv_flags (implement_lazy_force_env Σ) ∥.
+Proof.
+  intros wf v. induction wf. sq. constructor.
+  depelim v. depelim X. specialize (IHwf (sq X)). sq. cbn. constructor => //.
+  destruct d as [[[dbody|]]|]; cbn in * |-; try solve [constructor; auto].
+  cbn -[implement_lazy_force]. 
+  eapply value_pres; tea.
+Qed.
+
 Program Definition implement_lazy_force_transformation (efl : EEnvFlags) (has_app : has_tApp) (has_lam : has_tLambda) (has_tbox : has_tBox)
-  (nocofix : has_tCoFix = false) (nopars : has_cstr_params = false) :
+  (nocofix : has_tCoFix = false) (nopars : has_cstr_params = false) (pres_values : bool) :
   Transform.t _ _ EAst.term EAst.term _ _ (eval_eprogram block_wcbv_flags) (eval_eprogram block_wcbv_flags) :=
   {| name := "implementing lazy and force using lambdas ";
     transform p _ := implement_lazy_force_program p ;
-    pre p := wf_eprogram efl p ;
-    post p := wf_eprogram (switch_off_thunk efl) p ;
+    pre p := wf_eprogram efl p /\ (if pres_values then ∥ @values_glob block_wcbv_flags p.1 ∥ else True) ;
+    post p := wf_eprogram (switch_off_thunk efl) p /\ 
+      (if pres_values then ∥ @values_glob block_wcbv_flags p.1 ∥ else True) ;
     obseq p hp p' v v' := v' = implement_lazy_force v |}.
 Next Obligation.
-  intros efl hasapp haslam hasbox nocof nopars p wf. cbn. cbn in wf.
-  split. eapply implement_lazy_force_env_wf_glob; eauto. apply wf.
-  apply transform_wellformed'; eauto. all:apply wf.
+  intros efl hasapp haslam hasbox nocof nopars pvals p [wfp hpres].
+  split.
+  - split. eapply implement_lazy_force_env_wf_glob; eauto. apply wfp.
+    apply transform_wellformed'; eauto. all:apply wfp.
+  - destruct pvals => //. eapply values_glob_pres; eauto. apply wfp.
 Qed.
 Next Obligation.
-  intros efl hasapp haslam hasbox nocof nopars p t wf ev.
+  intros efl hasapp haslam hasbox nocof nopars pvals p t [wf hpres] ev.
   destruct p as [g p]. destruct wf, ev; cbn in * |-.
   eexists. split; [| eauto].
   split.

--- a/erasure/theories/EConstantsToValues.v
+++ b/erasure/theories/EConstantsToValues.v
@@ -600,12 +600,17 @@ Proof.
   now simple.
 Qed.
 
-
-
-
 Theorem consts_to_values_env_values {wfl : WcbvFlags} (Σ : global_context) :
   values_glob (consts_to_values_env Σ).
 Proof.
   induction Σ as [|[kn [[[v|]]|?]] Σ IH]; simpl;
     repeat constructor; assumption.
+Qed.
+
+Theorem consts_to_values_env_lazy {wfl : WcbvFlags} (Σ : global_context) :
+  lazy_glob (consts_to_values_env Σ).
+Proof.
+  induction Σ as [|[kn [[[v|]]|?]] Σ IH]; simpl;
+    repeat constructor; try assumption.
+  cbn. red. now eexists.
 Qed.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -342,23 +342,38 @@ Section Wcbv.
 
 End Wcbv.
 
-(** Characterisation of an environment where all declarations with a body map to a value *)
-Definition value_decl {wfl : WcbvFlags} (Σ : global_context) (d : global_decl) :=
+(** Characterisation of an environment where all definition bodies satisfy some predicate *)
+Definition decl_pred (pred : term -> Type) (d : global_decl) :=
   match d with
-  | ConstantDecl {| cst_body := Some v |} => value Σ v
+  | ConstantDecl {| cst_body := Some v |} => pred v
   | _ => True
   end.
 
-Inductive values_glob {wfl : WcbvFlags} : global_context -> Type :=
-| values_glob_nil : values_glob []
-| values_glob_cons 
+Inductive glob_pred (pred : global_context -> term -> Type) : global_context -> Type :=
+| glob_pred_nil : glob_pred pred []
+| glob_cons 
     (kn : kername) (d : global_decl) (Σ : global_context) :
-    values_glob Σ ->
-    value_decl Σ d ->
-    values_glob ((kn, d) :: Σ)
+    glob_pred pred Σ ->
+    decl_pred (pred Σ) d ->
+    glob_pred pred ((kn, d) :: Σ)
 .
-Derive Signature for values_glob.
+Derive Signature for glob_pred.
 
+(** Characterisation of an environment where all definition bodies are values *)
+Definition values_glob {wfl : WcbvFlags} := glob_pred (@value wfl).
+
+Definition lazy_value_pred (Σ : global_context) (v : term) :=
+  exists t, v = tLazy t.
+
+(** Characterisation of an environment where all declarations with a body map to a lazy value *)
+Definition lazy_glob : global_context -> Type :=
+  glob_pred lazy_value_pred.
+
+Definition lambda_value_pred (Σ : global_context) (v : term) :=
+  exists na t, v = tLambda na t.
+
+Definition lambda_glob : global_context -> Type :=
+  glob_pred lambda_value_pred.
 
 Notation atomic Σ := (atomic_value Σ (value Σ)).
 

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -72,8 +72,8 @@ Proof. destruct p as [? []]; auto. Qed.
 Definition all_term_flags :=
   {| has_tBox := true
     ; has_tRel := true
-    ; has_tVar := true
-    ; has_tEvar := true
+    ; has_tVar := false
+    ; has_tEvar := false
     ; has_tLambda := true
     ; has_tLetIn := true
     ; has_tApp := true
@@ -98,30 +98,6 @@ Definition all_env_flags_blocks :=
      term_switches := all_term_flags;
      has_cstr_params := true ;
      cstr_as_blocks := true |}.
-
-Definition erased_term_flags :=
-  {| has_tBox := true
-    ; has_tRel := true
-    ; has_tVar := false
-    ; has_tEvar := false
-    ; has_tLambda := true
-    ; has_tLetIn := true
-    ; has_tApp := true
-    ; has_tConst := true
-    ; has_tConstruct := true
-    ; has_tCase := true
-    ; has_tProj := true
-    ; has_tFix := true
-    ; has_tCoFix := true
-    ; has_tPrim := all_primitive_flags
-    ; has_tLazy_Force := true (* Actually not possible *)
-  |}.
-
-Definition erased_env_flags :=
-  {| has_axioms := true;
-     term_switches := erased_term_flags;
-     has_cstr_params := true ;
-     cstr_as_blocks := false |}.
 
 Section wf.
 

--- a/erasure/theories/ErasureFunctionProperties.v
+++ b/erasure/theories/ErasureFunctionProperties.v
@@ -1420,7 +1420,7 @@ Section wffix.
   Fixpoint wf_fixpoints (t : term) : bool :=
     match t with
     | tRel i => true
-    | tEvar ev args => List.forallb (wf_fixpoints) args
+    | tEvar ev args => false
     | tLambda N M => wf_fixpoints M
     | tApp u v => wf_fixpoints u && wf_fixpoints v
     | tLetIn na b b' => wf_fixpoints b && wf_fixpoints b'
@@ -1434,7 +1434,7 @@ Section wffix.
       (idx <? #|mfix|) && List.forallb (wf_fixpoints ∘ dbody) mfix
     | tConst kn => true
     | tConstruct ind c _ => true
-    | tVar _ => true
+    | tVar _ => false
     | tBox => true
     | tPrim p => test_prim wf_fixpoints p
     | tLazy t => wf_fixpoints t

--- a/erasure/theories/ErasureProperties.v
+++ b/erasure/theories/ErasureProperties.v
@@ -485,7 +485,7 @@ Section wellscoped.
   match t with
   | tRel i => true
   | tPrim p => test_prim wellformed p
-  | tEvar ev args => List.forallb (wellformed) args
+  | tEvar ev args => false
   | tLambda _ N M => wellformed N && wellformed M
   | tApp u v => wellformed u && wellformed v
   | tLetIn na b ty b' => wellformed b && wellformed ty && wellformed b'
@@ -501,7 +501,7 @@ Section wellscoped.
     List.forallb (test_def wellformed wellformed) mfix
   | tConst kn _ => isSome (lookup_constant Σ kn)
   | tConstruct ind c _ => isSome (lookup_constructor Σ ind c)
-  | tVar _ => true
+  | tVar _ => false
   | tInd ind _  => isSome (lookup_inductive Σ ind)
   | tSort _ => true
   | tProd na ty1 ty2 => wellformed ty1 && wellformed ty2


### PR DESCRIPTION
This refines the invariants on global environments imposed by erasure (no EVar or Var constructors) and constants-to-values, as necessary for the current CertiRocq correctness proofs.